### PR TITLE
Fix Sloth not working when used with Road Runner

### DIFF
--- a/src/main/kotlin/dev/frozenmilk/sinister/targeting/WideSearch.kt
+++ b/src/main/kotlin/dev/frozenmilk/sinister/targeting/WideSearch.kt
@@ -19,5 +19,6 @@ open class WideSearch : FullSearch() {
 		exclude("org.tensorflow")
 		exclude("org.threeten")
 		exclude("com.journeyapps")
+		exclude("com.jacksonxml")
 	}
 }

--- a/src/main/kotlin/dev/frozenmilk/sinister/targeting/WideSearch.kt
+++ b/src/main/kotlin/dev/frozenmilk/sinister/targeting/WideSearch.kt
@@ -19,6 +19,6 @@ open class WideSearch : FullSearch() {
 		exclude("org.tensorflow")
 		exclude("org.threeten")
 		exclude("com.journeyapps")
-		exclude("com.jacksonxml")
+		exclude("com.fasterxml")
 	}
 }


### PR DESCRIPTION
(Original Issue description is in the Dairy Foundation [discord](https://discord.gg/KsUXVNrF5q) in [this message](https://discord.com/channels/1168220554050949252/1360719329426935848/1360719329426935848))

This PR (hopefully) fixes Sloth when used with RR. Currently, FasterXML is a dependency of RR and FasterXML uses `java.nio.file.Path` which apparently [doesn't work on android devices](https://github.com/getsentry/sentry-java/issues/493), so Sloth's scanners error out when they try to do reflection on `java.nio.file.Path`.

This PR excludes FasterXML classes from the WideSearch, which (I think?) determines what will be scanned.

I haven't tested this change yet, but I will try to the next time I have access to our robot.